### PR TITLE
Implement VOOG intro overlay targets

### DIFF
--- a/components/edicy-tools-variables.tpl
+++ b/components/edicy-tools-variables.tpl
@@ -86,4 +86,10 @@
   {% else %}
     {% assign content_right_bg_color_data_str = content_right_bg_color_data | json %}
   {% endif %}
+
+  {% comment %}VOOG intro popover targets. Add them where applicable popovers should appear.{% endcomment %}
+  {% capture edy_intro_add_page %}{% if editmode %}data-edy-intro-popover="edy-add-page"{% endif %}{% endcapture %}
+  {% capture edy_intro_add_lang %}{% if editmode %}data-edy-intro-popover="edy-add-lang"{% endif %}{% endcapture %}
+  {% capture edy_intro_edit_text %}{% if editmode %}data-edy-intro-popover="edy-edit-text"{% endif %}{% endcapture %}
+
 {% endcapture %}

--- a/components/langmenu.tpl
+++ b/components/langmenu.tpl
@@ -1,6 +1,6 @@
 {% if editmode or site.has_many_languages? %}
-  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
-    <button role="button" class="lang-menu-btn js-popup-menu-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
+  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+    <button role="button" class="lang-menu-btn js-popup-menu-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}" {{ edy_intro_add_lang }}>
 
       {% if editmode or flags_state == nil or flags_state == false %}
       <span class="lang-title">

--- a/components/langmenu.tpl
+++ b/components/langmenu.tpl
@@ -1,5 +1,5 @@
 {% if editmode or site.has_many_languages? %}
-  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
     <button role="button" class="lang-menu-btn js-popup-menu-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
 
       {% if editmode or flags_state == nil or flags_state == false %}

--- a/components/mainmenu.tpl
+++ b/components/mainmenu.tpl
@@ -33,7 +33,7 @@
             <li>{% menubtn site.hidden_menuitems %}</li>
           {% endif %}
 
-          <li>{% menuadd %}</li>
+          <li {{ edy_intro_add_page }}>{% menuadd %}</li>
         {% endif %}
       </ul>
     </div>

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -21,7 +21,7 @@
               </header>
               <section class="post-content">
                 <div class="post-excerpt cfx formatted">{% editable article.excerpt %}</div>
-                <div class="post-body cfx formatted">{% editable article.body %}</div>
+                <div class="post-body cfx formatted" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
 
                 {% if editmode or article.tags.size > 0 %}
                 <div class="post-tags">

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -20,8 +20,8 @@
                 <h1>{% editable article.title %}<time class="post-date" datetime="{{ article.created_at | date : "%Y %m %d" }}">{{ article.created_at | format_date: "long" }}</time></h1>
               </header>
               <section class="post-content">
-                <div class="post-excerpt cfx formatted">{% editable article.excerpt %}</div>
-                <div class="post-body cfx formatted" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
+                <div class="post-excerpt cfx formatted" {{ edy_intro_edit_text }}>{% editable article.excerpt %}</div>
+                <div class="post-body cfx formatted">{% editable article.body %}</div>
 
                 {% if editmode or article.tags.size > 0 %}
                 <div class="post-tags">

--- a/layouts/common_page.tpl
+++ b/layouts/common_page.tpl
@@ -19,7 +19,7 @@
             <div class="content formatted cfx">
               <div class="content-header">{% contentblock name="content_header" %}<h1>{{ page.title }}</h1>{% endcontentblock %}</div>
               {% include "submenu" %}
-              <div class="content-body">{% content %}</div>
+              <div class="content-body" {{ edy_intro_edit_text }}>{% content %}</div>
             </div>
           </div>
         </div>

--- a/layouts/front_page.tpl
+++ b/layouts/front_page.tpl
@@ -19,7 +19,7 @@
           <div class="background-color js-background-color"></div>
           <div class="inner js-background-type {{ content_left_bg_type }}">
             <div class="align-middle">
-              <div class="content formatted cfx">{% content %}</div>
+              <div class="content formatted cfx" {{ edy_intro_edit_text }}>{% content %}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Current targetable areas are:
```
data-edy-intro-popover="edy-add-page"
data-edy-intro-popover="edy-add-lang"
data-edy-intro-popover="edy-edit-text"
```