### PR TITLE
Make template link style stronger

### DIFF
--- a/components/template-cs-style-rules.tpl
+++ b/components/template-cs-style-rules.tpl
@@ -72,9 +72,9 @@ main .post-content {
   line-height: var(--content-line-height);
 }
 
-main .content-body a,
+main .content-wrap .content-body a,
 main .post-content a,
-main .footer-content a {
+footer.footer .footer-content a {
   color: var(--content-links-color);
   font-style: var(--content-links-font-style);
   font-weight: var(--content-links-font-weight);
@@ -82,9 +82,9 @@ main .footer-content a {
           text-decoration: var(--content-links-text-decoration);
   text-transform: var(--content-links-text-transform);
 }
-main .content-body a:hover,
+main .content-wrap .content-body a:hover,
 main .post-content a:hover,
-main .footer-content a:hover {
+footer.footer .footer-content a:hover {
   color: var(--content-links-hover-color);
   font-style: var(--content-links-hover-font-style);
   font-weight: var(--content-links-hover-font-weight);

--- a/sources/components/custom-styles/template-cs-style-rules.scss
+++ b/sources/components/custom-styles/template-cs-style-rules.scss
@@ -97,9 +97,9 @@ main .post-content {
   line-height: var(--content-line-height);
 }
 
-main .content-body,
+main .content-wrap .content-body,
 main .post-content,
-main .footer-content {
+footer.footer .footer-content {
   a {
     color: var(--content-links-color);
     font-style: var(--content-links-font-style);


### PR DESCRIPTION
Tava lingi hover stiil kirjutas üle tekstieditorist määratud ingi hover stiil stiili:
```
 .formatted a:hover:not(.post-nav-link) {
    color: #fff;
}
```
vs
```
main .content-body a:hover, main .post-content a:hover, main .footer-content a:hover {
    color: var(--content-links-hover-color);
}
```

Sellest tulenevalt tehti globaalset editori stiili tugevamaks.
Close #104 

Testida `content-body` ja `footer-content` klassiga konteineris olevate linkide hover värve. Kontrollida ka üle ega antud muudatused ei mõjuta teisi elemente.